### PR TITLE
Add blue lights on failed request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /*.pyc
 /*.zip
 /config.yml
+__pycache__/
+.pytest_cache/

--- a/download_worker.py
+++ b/download_worker.py
@@ -1,6 +1,7 @@
 import json
 import requests
 
+
 class DownloadWorker():
     def __init__(self, api_token):
         if not api_token:
@@ -9,9 +10,15 @@ class DownloadWorker():
 
     def make_request(self, url):
         token = "Bearer {token}".format(token=self.api_token)
-        auth_header = { "Authorization": token }
+        auth_header = {"Authorization": token}
         return requests.get(url=url, headers=auth_header,)
 
+    def get_json(self, url):
+        json.loads(self.make_request(url).content)
+
     def fetch_first_eight_build_states(self, url):
-        response = json.loads(self.make_request(url).content)
-        return [build['state'] for build in response][:8]
+        try:
+            response = self.get_json(url)
+            return [build['state'] for build in response][:8]
+        except:
+            return ['error' for _ in range(8)]

--- a/status_light.py
+++ b/status_light.py
@@ -61,6 +61,9 @@ def black():
 def brown():
     return (165, 42, 42)
 
+def blue():
+    return (0, 0, 128)
+
 def purple():
     return (128, 0, 128)
 
@@ -82,6 +85,7 @@ def state_to_color(color):
         'scheduled': pink(),
         'blocked': purple(),
         'canceling': orange(),
+        'error': blue(),
         'skipped': brown(),
         'not_run': black(),
         'finished': grey(),

--- a/test_download_worker.py
+++ b/test_download_worker.py
@@ -1,0 +1,52 @@
+import unittest
+from download_worker import DownloadWorker
+import requests_mock
+
+
+class DownloadWorkerTest(unittest.TestCase):
+    @requests_mock.mock()
+    def test_fetch_first_eight_build_states(self, m):
+        dw = DownloadWorker('api_token')
+        m.get('http://aurl.com', text='<html><body></body></html>')
+        expected = ['error' for _ in range(8)]
+        actual = dw.fetch_first_eight_build_states('http://aurl.com')
+        self.assertEqual(actual, expected)
+
+        m.get('http://burl.com', text='{"json": { "valid": true} }')
+        expected = ['error' for _ in range(8)]
+        actual = dw.fetch_first_eight_build_states('http://burl.com')
+        self.assertEqual(actual, expected)
+
+        m.get('http://curl.com', text='not html')
+        actual = dw.fetch_first_eight_build_states('http://curl.com')
+        expected = ['error' for _ in range(8)]
+        self.assertEqual(actual, expected)
+
+    @requests_mock.mock()
+    def test_fetch_first_eight_build_states_with_invalid_json(self, m):
+        url = 'http://jsonplaceholder.typicode.com/todos'
+        api_token = 'foo'
+        worker = DownloadWorker(api_token)
+        actual = worker.fetch_first_eight_build_states(url)
+        expected = ['error' for _ in range(8)]
+        self.assertEqual(actual, expected)
+
+    @requests_mock.mock()
+    def test_fetch_first_eight_build_states_with_invalid_url(self, m):
+        url = 'http://google.com'
+        api_token = 'foo'
+        worker = DownloadWorker(api_token)
+        actual = worker.fetch_first_eight_build_states(url)
+        expected = ['error' for _ in range(8)]
+        self.assertEqual(actual, expected)
+
+    def test_fetch_first_eight_build_states_with_valid_json(self):
+        url = 'http://buildkite'
+        api_token = 'foo'
+        worker = DownloadWorker(api_token)
+        actual = worker.fetch_first_eight_build_states(url)
+        expected = ['error' for _ in range(8)]
+        self.assertEqual(actual, expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Recovers from failed request for CI status with a blue row, rather than sticking to rainbow colors.